### PR TITLE
Make it work on osx

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,64 +1,75 @@
-const path = require('path')
-const os = require('os')
-const fs = require('fs')
-const { exec } = require('child_process')
-const { CompositeDisposable } = require('atom')
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const { exec } = require("child_process");
+const { CompositeDisposable } = require("atom");
 
 module.exports = {
   activate() {
-    this.subscriptions = new CompositeDisposable()
-    this.subscriptions.add(atom.workspace.observeTextEditors(textEditor => {
-      this.subscriptions.add(textEditor.onDidSave(handleDidSave.bind(this)))
-    }))
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(
+      atom.workspace.observeTextEditors(textEditor => {
+        this.subscriptions.add(textEditor.onDidSave(handleDidSave.bind(this)));
+      })
+    );
+  }
+};
+
+function handleDidSave(event) {
+  const configPath = findConfigPath(event.path);
+  if (configPath) {
+    execTcr(configPath);
   }
 }
 
-function handleDidSave() {
-  const localConfigPath = path.join(process.cwd(), '.tcr')
-  const homeConfigPath = path.join(os.homedir(), '.tcr')
-  if (fs.existsSync(localConfigPath)) {
-    execTcr(localConfigPath)
-  } else if (fs.existsSync(homeConfigPath)) {
-    execTcr(homeConfigPath)
-  }
+function findConfigPath(startPath) {
+  const potentialPath = path.join(startPath, "./.tcr");
+  if (fs.existsSync(potentialPath)) return potentialPath;
+  if (startPath === os.homedir()) return null;
+  return findConfigPath(path.join(startPath, ".."));
 }
 
 function execTcr(configPath) {
-  const config = parseConfig(configPath)
-  exec(config.test, {}, (err, stdout, stderr) => {
-    fs.writeFileSync('./.tcr-feedback', `STDERR\n------\n${stderr}\n\nSTDOUT\n------\n${stdout}`)
+  const config = parseConfig(configPath);
+  const cwd = path.join(configPath, "..");
+  exec(config.test, { cwd }, (err, stdout, stderr) => {
+    fs.writeFileSync(
+      path.join(cwd, "./.tcr-feedback"),
+      `STDERR\n------\n${stderr}\n\nSTDOUT\n------\n${stdout}`
+    );
     if (err) {
-      execWithErrorNotification(config.revert)
+      execWithErrorNotification(config.revert, cwd);
     } else {
-      execWithErrorNotification(config.commit)
+      execWithErrorNotification(config.commit, cwd);
     }
-  })
+  });
 }
 
 function parseConfig(configPath) {
   try {
-    return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+    return JSON.parse(fs.readFileSync(configPath, "utf-8"));
   } catch (err) {
     showErrorNotification({
       message: `atom-tcr failed to parse config at ${configPath}:`,
       detail: err.stack
-    })
+    });
   }
 }
 
 function showErrorNotification({ message, detail }) {
   atom.notifications.addError(message, {
-    detail, dismissable: true
-  })
+    detail,
+    dismissable: true
+  });
 }
 
-function execWithErrorNotification(command) {
-  exec(command, {}, (err, stdout, stderr) => {
+function execWithErrorNotification(command, cwd) {
+  exec(command, { cwd }, (err, stdout, stderr) => {
     if (err) {
       showErrorNotification({
         message: `atom-tcr failed running ${command}`,
         detail: stderr.trim() || (err && err.message)
-      })
+      });
     }
-  })
+  });
 }


### PR DESCRIPTION
OSX seems to run atom with a different `cwd` so this recurses up the directory tree until it finds a `.tcr` config file.